### PR TITLE
Alpha support for multiple secret backends

### DIFF
--- a/app/elements/secrets-init.html
+++ b/app/elements/secrets-init.html
@@ -71,6 +71,11 @@ limitations under the License.
 					secretAccess: {
 						type: Object,
 						value: {}
+					},
+					backends: {
+						type: Array,
+						value: [],
+						notify: true
 					}
 				},
 				// ---------- SECRETS ----------
@@ -100,6 +105,7 @@ limitations under the License.
 				_addSecret: function(location) {
 					var parts = location.split('/');
 					if (!['sys', 'auth', 'cubbyhole'].includes(parts[0])) {
+						if (!this.backends.includes(parts[0])) this.push('backends', parts[0]);
 						var type = location.endsWith('/') ? 'folder' : 'secret';
 						var permissions = [];
 						var keys = Object.keys(this.secretAccess).sort(function(a, b){ return b.length > a.length;}); //Sort by longest key to prioritize individual secret policies rather than wildcards

--- a/app/index.html
+++ b/app/index.html
@@ -33,7 +33,7 @@ limitations under the License.
 		<div id="blocker"></div>  <!-- blocker: an element to obscure background-loading content at load time. -->
 		<login-form status="{{status}}" username="{{u}}" url="{{url}}" header="{{header}}" login-response="{{loginResponse}}" loading="{{loading}}"></login-form>
 		<login-status id="login-status" status="{{status}}" url="{{url}}" header="{{header}}"></login-status>
-		<secrets-init status="{{status}}" header="{{header}}" login-response="{{loginResponse}}" secrets="{{secrets}}" access="{{access}}" loading="{{loading}}"></secrets-init>
+		<secrets-init status="{{status}}" header="{{header}}" login-response="{{loginResponse}}" secrets="{{secrets}}" access="{{access}}" loading="{{loading}}" backends="{{backends}}"></secrets-init>
 
 		<paper-drawer-panel id="paperDrawerPanel" drawer-width="{{drawerWidth}}">
 			<!-- Drawer Area -->
@@ -77,8 +77,12 @@ limitations under the License.
 						</a>
 					</paper-menu>
 
-					<span id="drawerMenuText" class="noselect">SECRETS</span>
-					<folder-structure secrets="[[secrets]]" route="{{route}}" folder-route="{{folderRoute}}" base-url="{{baseUrl}}" base-folder="secret" indent="20" create-location="{{createLocation}}" print></folder-structure>
+					<!-- List of backends -->
+					<template is="dom-repeat" items="{{backends}}">
+						<span id="drawerMenuText" class="noselect" style="text-transform: uppercase;">{{item}}</span>
+						<folder-structure secrets="[[secrets]]" route="{{route}}" folder-route="{{folderRoute}}" base-url="{{baseUrl}}" base-folder="{{item}}" indent="20" create-location="{{createLocation}}" print></folder-structure>
+					</template>
+
 				</div>
 
 				<!-- <div class="bottom-corner" style="color: #737373;">


### PR DESCRIPTION
This PR includes alpha support for multiple secret backends/engines.

This is marked as alpha, as anyone using the v2 secrets backend with versioned secrets will now see a "metadata" folder beneath each backend, but will not see secrets. Support for versioned secrets is currently being investigated. If the work required is small, it may be scheduled soon, but there are no guarantees. 