### PR TITLE
WIP - Add Vault Namespaces

### DIFF
--- a/app/bower.json
+++ b/app/bower.json
@@ -19,14 +19,14 @@
     "iron-elements": "^1.0.10",
     "paper-elements": "^1.0.7",
     "neon-elements": "^1.0.0",
-    "page": "^1.7.1",
+    "page": "^1.11.6",
     "juicy-jsoneditor": "^1.3.0",
-    "paper-toggle-button": "^2.0.0",
+    "paper-toggle-button": "^2.1.1",
     "font-roboto-local": "PolymerElements/font-roboto-local#^1.0.1",
-    "fuse.js": "^3.2.0",
+    "fuse.js": "^6.4.3",
     "app-storage": "PolymerElements/app-storage#^2.0.2"
   },
   "resolutions": {
-    "paper-toggle-button": "^2.0.0"
+    "paper-toggle-button": "^2.1.1"
   }
 }

--- a/app/elements/login-form.html
+++ b/app/elements/login-form.html
@@ -154,6 +154,9 @@ limitations under the License.
 					<paper-input id="passfield" value="{{password}}" label="Password" type="password" disabled="{{loading}}"></paper-input>
 				</div>
 			</iron-pages>
+			<div class="namespace">
+				<paper-input id="userfieldnamespace" value="{{namespace}}" label="Namespace" disabled="{{loading}}"></paper-input>
+			</div>
 			<div class="buttons">
 				<paper-button on-tap="_login" autofocus disabled="{{loading}}">Login</paper-button>
 			</div>
@@ -163,6 +166,7 @@ limitations under the License.
 		<app-localstorage-document key="page" data="{{page}}"></app-localstorage-document>
 		<app-localstorage-document key="urls" data="{{urls}}"></app-localstorage-document>
 		<app-localstorage-document key="username" data="{{username}}"></app-localstorage-document>
+		<app-localstorage-document key="namespace" data="{{namespace}}"></app-localstorage-document>
 		
 		<paper-toast id="errortoast" class="fit-bottom error" duration="5000">
 			<iron-icon prefix icon="error-outline" style="padding-right: 7px;"></iron-icon>
@@ -269,6 +273,10 @@ limitations under the License.
 					approvedURL: {
 						type: Boolean,
 						value: false
+					},
+					namespace: {
+						type: String,
+						value: '',
 					}
 				},
 				attached: function() {
@@ -299,6 +307,7 @@ limitations under the License.
 							this.authMethod = 'POST';
 							this.authURL = this.url + 'v1/auth/ldap/login/' + this.username;
 							this.body = {"password": this.password };
+							this.header = {"X-Cryptr-Version": app.cryptrVersion, "X-Vault-Namespace": this.namespace};
 						} else if (this.page == 1) {
 							if (!this.token) { //Check field has content
 								this.errorText = 'Token is required';
@@ -308,7 +317,7 @@ limitations under the License.
 							}
 							this.authMethod = 'GET';
 							this.authURL = this.url + 'v1/auth/token/lookup-self';
-							this.header = {"X-Vault-Token": this.token, "X-Cryptr-Version": app.cryptrVersion };
+							this.header = {"X-Vault-Token": this.token, "X-Cryptr-Version": app.cryptrVersion, "X-Vault-Namespace": this.namespace};
 							this.body = '';
 						} else if (this.page == 2) {
 							if (!this.username && !this.password) { //Check fields have content
@@ -319,6 +328,7 @@ limitations under the License.
 							}
 							this.authMethod = 'POST';
 							this.authURL = this.url + 'v1/auth/userpass/login/' + this.username;
+							this.header = {"X-Cryptr-Version": app.cryptrVersion, "X-Vault-Namespace": this.namespace};
 							this.body = {"password": this.password };
 						}
 						this.loading = true;
@@ -329,7 +339,7 @@ limitations under the License.
 					// UserPass / LDAP
 					if (this.loginResponse.auth && this.loginResponse.auth.client_token) {
 						this.loginResponse = this.loginResponse.auth;
-						this.header = {"X-Vault-Token": this.loginResponse.client_token, "X-Cryptr-Version": app.cryptrVersion };
+						this.header = {"X-Vault-Token": this.loginResponse.client_token, "X-Cryptr-Version": app.cryptrVersion, "X-Vault-Namespace": this.namespace};
 					// Token Auth
 					} else if (this.loginResponse.data) {
 						this.loginResponse = this.loginResponse.data;

--- a/app/elements/search-box.html
+++ b/app/elements/search-box.html
@@ -41,6 +41,8 @@ limitations under the License.
 	</template>
 
 	<script>
+		// https://github.com/visionmedia/page.js/issues/537#issuecomment-492755878
+		page.configure({window:window})
 		Polymer({
 			is: "search-box",
 			properties: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "chai": "^3.5.0",
         "chai-as-promised": "^5.3.0",
         "cross-env": "^5.2.1",
-        "electron": "^4.2.12",
+        "electron": "^11.0.3",
         "electron-builder": "^22.3.2",
         "electron-prebuilt": "^1.4.13",
         "mocha": "^5.2.0"


### PR DESCRIPTION
## Proposed changes

First proposal on how to add the [Vault Enterprise Namespace](https://www.vaultproject.io/docs/enterprise/namespaces) feature to Cryptr. This should in the long run fix #51 and currently has the maturity of a PoC.

## Types of changes

What types of changes does your code introduce to Cryptr?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have signed the [CLA](http://adobe.github.io/cla.html)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'm pretty inexperienced with Electron and NodeJS development and therefore only trying to get things started towards the implementation of Vault Namespaces in Cryptr. This PR should serve as a PoC to show the level of work required to introduce the support for the Namespace feature in Cryptr.

On remark regarding several package and dependency upgrades this PR includes: I was not able to get Cryptr up and running via `npm dev run` with the current master `package.json` and the older Electron version used. I tried and errored myself trough some of the dependency upgrades until I was able to run Cryptr on my machine from source. I would highly appreciate some guidance on the updates I introduced and if they make sense at all.

Currently there are some _decisions_ to be taken for the integration of namespaces:
- [ ] Where and how to display the namespaces selector/text field. In the current version I went for something similar as the official Vault UI does:
![image](https://user-images.githubusercontent.com/456036/113001708-5d71c080-9171-11eb-9f0f-4c76801ddb9f.png)
- [ ] Do we need a display for the currently selected namespace _inside_ Cryptr for better usability?
- [ ] Is there anything I didn't think about?

Looking forward to some feedback on this one.

One can this PR with a current enterprise binary from Vault running in dev mode and a namespaces with appropriate policies created:
```
$ vault+ent server -dev
$ vault namespace create cryptr-test
```